### PR TITLE
Cheats added, PlayerStats now derives from Stats

### DIFF
--- a/bobberick-demo/CMakeLists.txt
+++ b/bobberick-demo/CMakeLists.txt
@@ -25,6 +25,7 @@ components/ItemComponent.h
 components/WeaponComponent.cpp components/WeaponComponent.h
 components/InventoryComponent.cpp components/InventoryComponent.h
 systems/PlayerInputSystem.cpp systems/PlayerInputSystem.h
+systems/CheatSystem.cpp systems/CheatSystem.h
 systems/BulletSystem.cpp systems/BulletSystem.h
 systems/ShieldSystem.cpp systems/ShieldSystem.h
 systems/HudSystem.cpp systems/HudSystem.h 

--- a/bobberick-demo/components/PlayerStatsComponent.cpp
+++ b/bobberick-demo/components/PlayerStatsComponent.cpp
@@ -2,18 +2,23 @@
 #include "StatsComponent.h"
 #include "WeaponComponent.h"
 
-PlayerStatsComponent::PlayerStatsComponent(StatsComponent* stats, const double shdTime, const double shdTimeMax, const double shdRecov, const int gold, const int xp) {
+PlayerStatsComponent::PlayerStatsComponent(const int hp, const int hpMax, const int atMin, const int atMax, const int df, const int level, const double shdTime, const double shdTimeMax, const double shdRecov, const int gold, const int xp) : StatsComponent(hp, hpMax, atMin, atMax, df, level) {
 	PlayerStatsComponent::shdTime = shdTime;
 	PlayerStatsComponent::shdTimeMax = shdTimeMax;
 	PlayerStatsComponent::shdRecov = shdRecov;
 	shdActive = false;
 	PlayerStatsComponent::gold = gold;
 	PlayerStatsComponent::xp = xp;
-	PlayerStatsComponent::stats = stats;
 }
 
 void PlayerStatsComponent::update() {
-	if (stats->getHP() > 0) { // Shield recovery freezes when the player is dead.
+	if (gold > 999999) {
+		gold = 999999;
+	}
+	if (xp > 999999) {
+		xp = 999999;
+	}
+	if (getHP() > 0) { // Shield recovery freezes when the player is dead.
 		if (shdActive) {
 			shdTime -= 1;
 			if (shdTime <= 0) {
@@ -31,8 +36,8 @@ void PlayerStatsComponent::update() {
 	}
 }
 
-int PlayerStatsComponent::attack(bool magic, int seed) const {
-	int basePow = stats->attack(seed);
+int PlayerStatsComponent::attack(bool magic) const {
+	int basePow = generator.getRandomNumber(atMin, atMax);
 	if (magic) {
 		return basePow + magicWeapon->power;
 	} else {
@@ -62,11 +67,15 @@ const bool PlayerStatsComponent::shieldActive() const {
 
 void PlayerStatsComponent::getHit(int attack, const bool pierceDF) {
 	if (!shdActive) {
-		stats->getHit(attack, pierceDF); // Shield mode not active, get hit normally.
+		if (!pierceDF) {
+			attack -= df;
+			if (attack < 1) {
+				attack = 1;
+			}
+		}
+		hp -= attack;
+		if (hp < 0) {
+			hp = 0;
+		}
 	}
-}
-
-PlayerStatsComponent::~PlayerStatsComponent()
-{
-	//delete stats;
 }

--- a/bobberick-demo/components/PlayerStatsComponent.h
+++ b/bobberick-demo/components/PlayerStatsComponent.h
@@ -5,23 +5,21 @@
 #include "StatsComponent.h"
 
 class WeaponComponent;
-class PlayerStatsComponent : public Component
+class PlayerStatsComponent : public StatsComponent
 {
 public:
-	PlayerStatsComponent(StatsComponent* stats, const double shdTime, const double shdTimeMax, const double shdRecov, const int gold, const int xp);
-	~PlayerStatsComponent() override;
+	PlayerStatsComponent(const int hp, const int hpMax, const int atMin, const int atMax, const int df, const int level, const double shdTime, const double shdTimeMax, const double shdRecov, const int gold, const int xp);
 
 	void update() override; // The shield is recovered in this function.
 
 	void getHit(int attack, const bool pierceDF); // Mitigate attack with DF in offensive mode or absorb it in shield mode.
 	// If an entity has a PlayerStatsComponent with a StatsComponent in it, call only the PlayerStatsComponent getHit() in your system.
 
-	int attack(bool magic, int seed) const; // Generate an attack and modify it based on the power of one of your weapons.
+	int attack(bool magic) const; // Generate an attack and modify it based on the power of one of your weapons.
 	void toggleShield(); // Activate the shield, if it's charged enough (currently must be at least 50% charged).
 	const bool shieldActive() const; // Returns true if the shield is currently active.
 	void equipWeapon(WeaponComponent* weapon);
 
-	StatsComponent* stats; // The Component containing the player's basic stats.
 	double shdTime; // The amount of ticks the shield can still be active.
 	double shdTimeMax; // The amount of ticks the shield can be active at most.
 	double shdRecov; // The amount of shdTime recovered every tick (when shield is inactive).

--- a/bobberick-demo/components/StatsComponent.cpp
+++ b/bobberick-demo/components/StatsComponent.cpp
@@ -8,6 +8,8 @@ StatsComponent::StatsComponent(const int hp, const int hpMax, const int atMin, c
 	changeATmin(atMin);
 	changeDF(df);
 	changeLevel(level);
+
+	generator = RandomGenerator();
 }
 
 void StatsComponent::healPoints(const int points) {
@@ -41,11 +43,8 @@ void StatsComponent::getHit(int attack, const bool pierceDF) {
 	}
 }
 
-int StatsComponent::attack(int seed) {
-	std::default_random_engine generator;
-	generator.seed(seed);
-	std::uniform_int_distribution<int> dist(atMin, atMax);
-	return dist(generator);
+int StatsComponent::attack() {
+	return generator.getRandomNumber(atMin, atMax);
 }
 
 const int StatsComponent::getHP() {
@@ -71,6 +70,9 @@ void StatsComponent::changeHPmax(const int amount) {
 	hpMax += amount;
 	if (hpMax < 1) {
 		hpMax = 1;
+	}
+	if (hpMax > 999999) {
+		hpMax = 999999;
 	}
 	if (hp > hpMax) {
 		hp = hpMax;

--- a/bobberick-demo/components/StatsComponent.h
+++ b/bobberick-demo/components/StatsComponent.h
@@ -2,6 +2,7 @@
 #define BOBBERICK_TOOLS_STATSCOMPONENT_H
 
 #include "../../bobberick-framework/src/entity/Component.h"
+#include "../../bobberick-framework/src/util/RandomGenerator.h"
 
 class StatsComponent : public Component
 {
@@ -10,8 +11,8 @@ public:
 
 	void healPoints(const int points); // Heal HP, up to X fixed points.
 	void healPercent(const int percentage); // Heal HP, up to X percent of HPmax.
-	void getHit(int attack, const bool pierceDF); // Mitigate attack with DF (unless pierceDF is true), then take the resulting damage.
-	int attack(int seed); // Return a random number between ATmin and ATmax (when hitting an enemy or when generating a bullet).
+	virtual void getHit(int attack, const bool pierceDF); // Mitigate attack with DF (unless pierceDF is true), then take the resulting damage.
+	int attack(); // Return a random number between ATmin and ATmax (when hitting an enemy or when generating a bullet).
 	
 	// Get the value of a stat.
 	const int getHP();
@@ -27,9 +28,8 @@ public:
 	void changeATmax(const int amount);
 	void changeDF(const int amount);
 	void changeLevel(const int amount);
-
-
-private:
+protected:
+	RandomGenerator generator;
 	int hp = 0; // current hit points
 	int hpMax = 0; // maximum hit points
 	int atMin = 0; // minimum attack

--- a/bobberick-demo/state/PlayState.cpp
+++ b/bobberick-demo/state/PlayState.cpp
@@ -107,7 +107,7 @@ Entity& PlayState::makePlayer() const
 	player.addComponent<PlayerMovementComponent>();
 
 	// 3 seconds (180 ticks) of shield mode, 3/10ths of a second recovered per second.
-	player.addComponent<PlayerStatsComponent>(new StatsComponent(100000, 100000, 1, 3, 1, 1), 180, 180, 0.3, 0, 0);
+	player.addComponent<PlayerStatsComponent>(1000, 1000, 1, 3, 1, 1, 180, 180, 0.3, 0, 0);
 
 	player.addComponent<TimerComponent>();
 	player.addComponent<ShootComponent>();

--- a/bobberick-demo/state/StateFactory.cpp
+++ b/bobberick-demo/state/StateFactory.cpp
@@ -10,6 +10,7 @@
 #include "../systems/BulletSystem.h"
 #include "../state/TestState.h"
 #include "../systems/ShieldSystem.h"
+#include "../systems/CheatSystem.h"
 #include "../state/CreditScreenState.h"
 #include "../systems/AISystem.h"
 #include "MainMenuState.h"
@@ -60,6 +61,7 @@ PlayState* StateFactory::createPlayState()
 	playState->addSystem(std::make_shared<CollisionSystem>(ServiceManager::Instance()->getService<EntityManager>()));
 	playState->addSystem(std::make_shared<InputSystem>(ServiceManager::Instance()->getService<EntityManager>()));
 	playState->addSystem(std::make_shared<PlayerInputSystem>(ServiceManager::Instance()->getService<EntityManager>()));
+	playState->addSystem(std::make_shared<CheatSystem>(ServiceManager::Instance()->getService<EntityManager>()));
 	playState->addSystem(std::make_shared<BulletSystem>(ServiceManager::Instance()->getService<EntityManager>()));
 	playState->addSystem(std::make_shared<ShieldSystem>(ServiceManager::Instance()->getService<EntityManager>()));
 	playState->addSystem(std::make_shared<DrawSystem>(ServiceManager::Instance()->getService<EntityManager>()));

--- a/bobberick-demo/systems/CheatSystem.cpp
+++ b/bobberick-demo/systems/CheatSystem.cpp
@@ -1,0 +1,44 @@
+#include "CheatSystem.h"
+#include "../../bobberick-framework/src/services/ServiceManager.h"
+#include "../../bobberick-framework/src/services/InputHandler.h"
+#include "../components/PlayerStatsComponent.h"
+
+CheatSystem::CheatSystem(EntityManager& entityManager) : System(entityManager)
+{
+}
+
+void CheatSystem::update()
+{
+	for (auto& entity : entityManager.getAllEntitiesWithComponent<PlayerStatsComponent>())
+	{
+		handleKeyInput(entity);
+	}
+}
+
+void CheatSystem::handleKeyInput(Entity* entity)
+{
+	auto& inputHandler = ServiceManager::Instance()->getService<InputHandler>();
+	auto& playerStats = entity->getComponent<PlayerStatsComponent>();
+
+	if (inputHandler.isKeyDown(SDL_SCANCODE_GRAVE))
+	{
+		if (inputHandler.isKeyDown(SDL_SCANCODE_G)) { // Get max gold
+			playerStats.gold = 999999;
+		} else if (inputHandler.isKeyDown(SDL_SCANCODE_E)) { // Get max experience
+			playerStats.xp = 999999;
+		} else if (inputHandler.isKeyDown(SDL_SCANCODE_H)) { // Get max health
+			playerStats.changeHPmax(999999);
+			playerStats.healPercent(100);
+		} else if (inputHandler.isKeyDown(SDL_SCANCODE_M)) { // Get a 10 second shield (M for mode)
+			playerStats.shdTime = 600;
+			if (!playerStats.shieldActive()) {
+				playerStats.toggleShield();
+			}
+		} else if (inputHandler.isKeyDown(SDL_SCANCODE_P)) { // Add 1000 attack power
+			playerStats.changeATmin(1000);
+			playerStats.changeATmax(1000);
+		}
+	}
+
+	
+}

--- a/bobberick-demo/systems/CheatSystem.h
+++ b/bobberick-demo/systems/CheatSystem.h
@@ -1,0 +1,17 @@
+#ifndef BOBBERICK_TOOLS_CHEATSYSTEM_H
+#define BOBBERICK_TOOLS_CHEATSYSTEM_H
+
+
+#include "../../bobberick-framework/src/entity/systems/System.h"
+
+class CheatSystem : public System
+{
+public:
+	explicit CheatSystem(EntityManager& entityManager);
+	void update() override;
+private:
+	void handleKeyInput(Entity* entity);
+};
+
+
+#endif //BOBBERICK_TOOLS_CHEATSYSTEM_H

--- a/bobberick-demo/systems/HudSystem.cpp
+++ b/bobberick-demo/systems/HudSystem.cpp
@@ -37,7 +37,7 @@ void HudSystem::update()
 		auto fps = std::to_string(ServiceManager::Instance()->getService<FrameHandler>().getCurrentFps());
 
 		playerStats.update();
-		const auto healthWidth = static_cast<double>(playerStats.stats->getHP()) / static_cast<double>(playerStats.stats->getHPmax()) * barWidth;
+		const auto healthWidth = static_cast<double>(playerStats.getHP()) / static_cast<double>(playerStats.getHPmax()) * barWidth;
 		const auto shieldWidth = playerStats.shdTime / playerStats.shdTimeMax * barWidth;
 		if (playerStats.shieldActive())
 		{
@@ -97,8 +97,8 @@ void HudSystem::update()
 
 		TextFormatter textFormatter = TextFormatter{};
 		healthText.getComponent<TextComponent>().setText(
-			textFormatter.addSpaces(std::to_string(playerStats.stats->getHP()), 6, true) + " / " + TextFormatter{}.addSpaces(
-				std::to_string(playerStats.stats->getHPmax()), 6, false));
+			textFormatter.addSpaces(std::to_string(playerStats.getHP()), 6, true) + " / " + TextFormatter{}.addSpaces(
+				std::to_string(playerStats.getHPmax()), 6, false));
 		coinText.getComponent<TextComponent>().setText(textFormatter.addSpaces(std::to_string(playerStats.gold), 6, false));
 		xpText.getComponent<TextComponent>().setText(textFormatter.addSpaces(std::to_string(playerStats.xp), 6, false));
 		fpsCounter.getComponent<TextComponent>().setText(textFormatter.addSpaces(fps, 6, false));

--- a/bobberick-framework/src/util/RandomGenerator.cpp
+++ b/bobberick-framework/src/util/RandomGenerator.cpp
@@ -2,14 +2,14 @@
 #include <random>
 #include <iostream>
 
-int RandomGenerator::getRandomNumber(int const first, int const second) {
+int RandomGenerator::getRandomNumber(int const first, int const second) const {
 	std::mt19937 rng;
 	rng.seed(std::random_device()());
 	std::uniform_int_distribution<std::mt19937::result_type> dist(first, second);
 	return dist(rng);
 }
 
-double RandomGenerator::getRandomDouble(double const first, double const second) {
+double RandomGenerator::getRandomDouble(double const first, double const second) const {
 	std::mt19937 rng;
 	rng.seed(std::random_device()());
 	std::uniform_real_distribution<double> dist(first, second);

--- a/bobberick-framework/src/util/RandomGenerator.h
+++ b/bobberick-framework/src/util/RandomGenerator.h
@@ -3,6 +3,6 @@
 class RandomGenerator
 {
 public:
-	int getRandomNumber(int const first, int const second);
-	double getRandomDouble(double const first, double const second);
+	int getRandomNumber(int const first, int const second) const;
+	double getRandomDouble(double const first, double const second) const;
 };


### PR DESCRIPTION
Alle methods en publieke variabelen van StatsComponent zijn nu ook beschikbaar in PlayerStatsComponent. PlayerStatsComponent::stats is verwijderd. Daarnaast zijn cheats toegevoegd waarmee de belangrijkste stats van de speler kunnen worden gemanipuleerd. Deze cheats staan in CheatSystem. **Hou ` ingedrukt** en druk op:
- G voor 999999 (max) gold.
- E voor 999999 (max) experience.
- H voor 999999 health en maximum health.
- M om een shield mode te activeren die 600 frames (10 seconden) duurt.
- P om minimum attack en maximum attack met 1000 te verhogen.

Omdat de cheats helpen bij debuggen, is de beginnende health van de speler nu slechts 1000.