### PR TITLE
Buttons now work intuitively

### DIFF
--- a/bobberick-framework/src/entity/components/ButtonComponent.cpp
+++ b/bobberick-framework/src/entity/components/ButtonComponent.cpp
@@ -2,7 +2,7 @@
 
 #include "ButtonComponent.h"
 
-ButtonComponent::ButtonComponent(std::function<void()> callback): callback(std::move(callback)), released(true)
+ButtonComponent::ButtonComponent(std::function<void()> callback): callback(std::move(callback)), released(false), pressed(false)
 {
 
 }
@@ -20,6 +20,16 @@ bool ButtonComponent::getReleased() const
 void ButtonComponent::setReleased(const bool cl)
 {
     released = cl;
+}
+
+bool ButtonComponent::getPressed() const
+{
+	return pressed;
+}
+
+void ButtonComponent::setPressed(const bool cl)
+{
+	pressed = cl;
 }
 
 void ButtonComponent::runCallback()

--- a/bobberick-framework/src/entity/components/ButtonComponent.h
+++ b/bobberick-framework/src/entity/components/ButtonComponent.h
@@ -19,9 +19,12 @@ public:
     void runCallback();
     bool getReleased() const;
     void setReleased(const bool cl);
+	bool getPressed() const;
+	void setPressed(const bool cl);
 private:
     std::function<void()> callback;
     bool released;
+	bool pressed;
 };
 
 

--- a/bobberick-framework/src/entity/systems/GuiSystem.cpp
+++ b/bobberick-framework/src/entity/systems/GuiSystem.cpp
@@ -29,16 +29,22 @@ void GuiSystem::update()
             spr.setCurrentFrame(1);
 
             if (inputHandler.getMouseButtonState(LEFT)) {
-                spr.setCurrentFrame(2);
-                if (bC.getReleased()) {
-                    bC.runCallback();
-                    bC.setReleased(false);
-                }
+				if (bC.getReleased()) {
+					spr.setCurrentFrame(2);
+					bC.setPressed(true);
+				}
             } else if (!inputHandler.getMouseButtonState(LEFT)) {
-                bC.setReleased(true);
+				bC.setReleased(true);
+				if (bC.getPressed()) {
+					bC.runCallback();
+					bC.setReleased(false);
+					bC.setPressed(false);
+				}
             }
         } else {
             spr.setCurrentFrame(0);
+			bC.setPressed(false);
+			bC.setReleased(false);
         }
 
         spr.update();


### PR DESCRIPTION
Knoppen werken precies zoals je het zou willen in een spel. Een ButtonComponent heeft nu een boolean 'pressed' en een boolean 'released', die worden in GuiSystem gebruikt om de knoppen juist te laten werken. In het kort: 

- Als je je muis ingedrukt houdt en daarna over een knop beweegt (of een ingedrukte muis begint de state toevallig boven een knop), komt hij pas in de 'losgelaten' staat als je de muisknop loslaat.
- Als de knop in de 'losgelaten' staat is en je houdt de muis (weer) ingedrukt, komt hij in de 'ingedrukte' staat. 
- Als je in de 'ingedrukte' staat de muis (weer) loslaat, wordt de callback aangeroepen en verlaat de knop die staat.
- Als je in de 'ingedrukte' staat van de knop af beweegt, verlaat de knop die staat zonder de callback aan te roepen.