### PR TITLE
Gold is gone

### DIFF
--- a/bobberick-demo/services/PlayerStatsService.cpp
+++ b/bobberick-demo/services/PlayerStatsService.cpp
@@ -5,7 +5,6 @@
 
 void PlayerStatsService::init()
 {
-	gold = 0;
 	if (xp > 0)
 	{
 		xpTotal += xp;
@@ -27,7 +26,7 @@ void PlayerStatsService::init()
 }
 
 void PlayerStatsService::setStats(const int hp, const int hpMax, const int atMin, const int atMax,
-                                  const double shdTime, const double shdTimeMax, const double shdRecov, const int gold,
+                                  const double shdTime, const double shdTimeMax, const double shdRecov,
                                   const int xp)
 {
 	PlayerStatsService::hp = hp;
@@ -37,7 +36,6 @@ void PlayerStatsService::setStats(const int hp, const int hpMax, const int atMin
 	PlayerStatsService::shdTime = shdTime;
 	PlayerStatsService::shdTimeMax = shdTimeMax;
 	PlayerStatsService::shdRecov = shdRecov;
-	PlayerStatsService::gold = gold;
 	PlayerStatsService::xp = xp;
 }
 
@@ -81,10 +79,6 @@ void PlayerStatsService::setMetaStats(const int xpTotal, const int hpLv, const i
 
 void PlayerStatsService::update()
 {
-	if (gold > 999999)
-	{
-		gold = 999999;
-	}
 	if (xp > 999999)
 	{
 		xp = 999999;
@@ -496,7 +490,6 @@ void PlayerStatsService::save()
 	save.keep<int>("hpMax", getHPmax());
 	save.keep<int>("atMin", getATmin());
 	save.keep<int>("atMax", getATmax());
-	save.keep<int>("gold", gold);
 	save.keep<double>("shdTime", shdTime);
 	save.keep<double>("shdTimeMax", getSHDmax());
 	save.keep<double>("shdRecov", getSHDrecov());
@@ -534,7 +527,6 @@ void PlayerStatsService::load()
 		save.get<double>("shdTime"),
 		save.get<double>("shdTimeMax"),
 		save.get<double>("shdRecov"),
-		save.get<int>("gold"),
 		save.get<int>("xp")
 	);
 
@@ -569,7 +561,6 @@ bool PlayerStatsService::validateSave() const
 	&& save.has("atMax")
 	&& save.has("shdTimeMax")
 	&& save.has("shdRecov")
-	&& save.has("gold")
 	&& save.has("w1IsMagic")
 	&& save.has("w1IsMagic")
 	&& save.has("w1FireDelay")

--- a/bobberick-demo/services/PlayerStatsService.h
+++ b/bobberick-demo/services/PlayerStatsService.h
@@ -8,7 +8,7 @@ class PlayerStatsService : public Service {
 public:
 	// Lifecycle events
 	void init() override; // Will reset the player based on the current skill levels, meant to be called more than once.
-	void setStats(const int hp, const int hpMax, const int atMin, const int atMax, const double shdTime, const double shdTimeMax, const double shdRecov, const int gold, const int xp); // Set stats when loading a in-progress game.
+	void setStats(const int hp, const int hpMax, const int atMin, const int atMax, const double shdTime, const double shdTimeMax, const double shdRecov, const int xp); // Set stats when loading a in-progress game.
 	void setWeapons(const WeaponComponent normal, const WeaponComponent magic); // Set initial weapons when loading a 'New Game +' save file(?)
 	void setMetaStats(const int totalXP, const int hpLv, const int atLv, const int shdTimeLv, const int shdRecovLv); // Initialize skills when loading the game.
 	void clean() override { };
@@ -71,7 +71,6 @@ public:
 	WeaponComponent comparingWeapon = WeaponComponent("", "", false, 0, 0, "", "");
 	int compareTime = 0; // When >0, the hud system should show the compared weapon. Depicts the amount of frames the compared weapon is valid.
 	bool compareConfirmed = false; // When true, this is a message to the collision system to destroy the colliding weapon and set this back to false when done.
-	int gold{};
 	int xp{}; // Earned in the current game.
 
 	void save(); // Save current game stats

--- a/bobberick-demo/state/Level1State.cpp
+++ b/bobberick-demo/state/Level1State.cpp
@@ -46,9 +46,6 @@ bool Level1State::onEnter()
 	                                                            SOUND_MUSIC);
 	ServiceManager::Instance()->getService<SoundManager>().playMusic("level1", -1);
 
-	WeaponFactory().generateWeapon(false, 0, 10, -9, 9); // For testing purposes
-	WeaponFactory().generateWeapon(true, 0, 10, -9, 9); // For testing purposes
-
 	instantiateSystems();
 
 	return true;

--- a/bobberick-demo/systems/CheatSystem.cpp
+++ b/bobberick-demo/systems/CheatSystem.cpp
@@ -24,12 +24,7 @@ void CheatSystem::handleKeyInput(Entity* entity)
 
 	if (inputHandler.isKeyDown(SDL_SCANCODE_GRAVE))
 	{
-		if (inputHandler.isKeyDown(SDL_SCANCODE_G))
-		{
-			// Get max gold
-			playerStats.gold = 999999;
-		}
-		else if (inputHandler.isKeyDown(SDL_SCANCODE_E))
+		if (inputHandler.isKeyDown(SDL_SCANCODE_E))
 		{
 			// Get max experience
 			playerStats.xp = 999999;

--- a/bobberick-demo/systems/HudSystem.cpp
+++ b/bobberick-demo/systems/HudSystem.cpp
@@ -21,8 +21,6 @@ HudSystem::HudSystem(EntityManager& entityManager) : System(entityManager),
                                                      healthBox(entityManager.addEntity()),
                                                      shieldBox(entityManager.addEntity()),
                                                      healthText(entityManager.addEntity()),
-                                                     coinImage(entityManager.addEntity()),
-                                                     coinText(entityManager.addEntity()),
                                                      xpImage(entityManager.addEntity()),
                                                      xpText(entityManager.addEntity()),
 													 oldWeaponName(entityManager.addEntity()),
@@ -94,7 +92,6 @@ void HudSystem::update()
 	healthText.getComponent<TextComponent>().setText(
 		textFormatter.addSpaces(std::to_string(playerStats.getHP()), 6, true) + " / " + TextFormatter{}.addSpaces(
 			std::to_string(playerStats.getHPmax()), 6, false));
-	coinText.getComponent<TextComponent>().setText(textFormatter.addSpaces(std::to_string(playerStats.gold), 6, false));
 	xpText.getComponent<TextComponent>().setText(textFormatter.addSpaces(std::to_string(playerStats.xp), 6, false));
 
 	if (fpsCounter.hasComponent<TextComponent>()) {
@@ -126,7 +123,7 @@ void HudSystem::init()
 	hudBox.addComponent<TransformComponent>(0, 0, 50, gameWidth, 1);
 	hudBox.addComponent<RectangleComponent>(51, 51, 204, true);
 
-	compareBox.addComponent<TransformComponent>(barWidth + 845, 50, 40, gameWidth - (barWidth + 345), 1); // Start off-screen.
+	compareBox.addComponent<TransformComponent>(barWidth + 785, 50, 40, gameWidth - (barWidth + 285), 1); // Start off-screen.
 	compareBox.addComponent<RectangleComponent>(51, 51, 204, true);
 
 	outerBox.addComponent<TransformComponent>(9, 9, 32, barWidth + 2, 1);
@@ -141,31 +138,25 @@ void HudSystem::init()
 	shieldBox.addComponent<TransformComponent>(10, 35, 5, barWidth, 1);
 	shieldBox.addComponent<RectangleComponent>(0, 255, 255, true);
 
-	coinImage.addComponent<TransformComponent>(barWidth + 17, 1, 48, 48, 1);
-	coinImage.addComponent<SpriteComponent>("hudGold", 1);
-
-	xpImage.addComponent<TransformComponent>(barWidth + 177, 1, 48, 48, 1);
+	xpImage.addComponent<TransformComponent>(barWidth + 17, 1, 48, 48, 1);
 	xpImage.addComponent<SpriteComponent>("hudXp", 1);
 
 	healthText.addComponent<TransformComponent>(20, 10, 30, 280, 1);
 	healthText.addComponent<TextComponent>("monoMedium", "healthText", " ");
 
-	coinText.addComponent<TransformComponent>(barWidth + 67, 10, 30, 110, 1);
-	coinText.addComponent<TextComponent>("monoMedium", "coinText", " ");
-
-	xpText.addComponent<TransformComponent>(barWidth + 227, 10, 30, 110, 1);
+	xpText.addComponent<TransformComponent>(barWidth + 67, 10, 30, 110, 1);
 	xpText.addComponent<TextComponent>("monoMedium", "xpText", " ");
 
-	oldWeaponName.addComponent<TransformComponent>(barWidth + 350, 7, 20, 300, 1);
+	oldWeaponName.addComponent<TransformComponent>(barWidth + 290, 7, 20, 360, 1);
 	oldWeaponName.addComponent<TextComponent>("monoSmall", "oldWeaponName", " ");
 
-	oldWeaponText.addComponent<TransformComponent>(barWidth + 350, 27, 20, 300, 1);
+	oldWeaponText.addComponent<TransformComponent>(barWidth + 290, 27, 20, 360, 1);
 	oldWeaponText.addComponent<TextComponent>("monoSmall", "oldWeaponText", " ");
 
-	newWeaponName.addComponent<TransformComponent>(barWidth + 350, 47, 20, 300, 1);
+	newWeaponName.addComponent<TransformComponent>(barWidth + 290, 47, 20, 360, 1);
 	newWeaponName.addComponent<TextComponent>("monoSmall", "newWeaponName", " ");
 
-	newWeaponText.addComponent<TransformComponent>(barWidth + 350, 67, 20, 300, 1);
+	newWeaponText.addComponent<TransformComponent>(barWidth + 290, 67, 20, 360, 1);
 	newWeaponText.addComponent<TextComponent>("monoSmall", "newWeaponText", " ");
 
 	inventory.addComponent<TransformComponent>(10, gameHeight - 60, 60, 130, 1);
@@ -202,10 +193,8 @@ void HudSystem::init()
 			serviceManager.addEntityToGroup(innerBox, group);
 			serviceManager.addEntityToGroup(healthBox, group);
 			serviceManager.addEntityToGroup(shieldBox, group);
-			serviceManager.addEntityToGroup(coinImage, group);
 			serviceManager.addEntityToGroup(xpImage, group);
 			serviceManager.addEntityToGroup(healthText, group);
-			serviceManager.addEntityToGroup(coinText, group);
 			serviceManager.addEntityToGroup(xpText, group);
 			serviceManager.addEntityToGroup(oldWeaponName, group);
 			serviceManager.addEntityToGroup(oldWeaponText, group);
@@ -224,10 +213,10 @@ void HudSystem::startCompare(WeaponComponent oldWeapon, WeaponComponent newWeapo
 	comparing = true;
 	
 	compareBox.getComponent<TransformComponent>().position.x -= 500; // Get on to the screen
-	oldWeaponName.getComponent<TextComponent>().setText(textFormatter.addSpaces(oldWeapon.name, 35, false));
-	oldWeaponText.getComponent<TextComponent>().setText(textFormatter.addSpaces("Old weapon: Power " + std::to_string(oldWeapon.power) + ", Delay " + std::to_string(oldWeapon.fireDelay), 35, false));
-	newWeaponName.getComponent<TextComponent>().setText(textFormatter.addSpaces(newWeapon.name, 35, false));
-	newWeaponText.getComponent<TextComponent>().setText(textFormatter.addSpaces("New weapon: Power " + std::to_string(newWeapon.power) + ", Delay " + std::to_string(newWeapon.fireDelay), 35, false));
+	oldWeaponName.getComponent<TextComponent>().setText(textFormatter.addSpaces(oldWeapon.name, 40, false));
+	oldWeaponText.getComponent<TextComponent>().setText(textFormatter.addSpaces("Old weapon: Power " + std::to_string(oldWeapon.power) + ", Delay " + std::to_string(oldWeapon.fireDelay), 40, false));
+	newWeaponName.getComponent<TextComponent>().setText(textFormatter.addSpaces(newWeapon.name, 40, false));
+	newWeaponText.getComponent<TextComponent>().setText(textFormatter.addSpaces("New weapon: Power " + std::to_string(newWeapon.power) + ", Delay " + std::to_string(newWeapon.fireDelay), 40, false));
 }
 
 void HudSystem::stopCompare() {

--- a/bobberick-demo/systems/HudSystem.h
+++ b/bobberick-demo/systems/HudSystem.h
@@ -28,8 +28,6 @@ private:
 	Entity& shieldBox; // The shield bar, inside the health bar.
 
 	Entity& healthText;
-	Entity& coinImage;
-	Entity& coinText;
 	Entity& xpImage;
 	Entity& xpText;
 


### PR DESCRIPTION
Het concept van 'gold' is in deze pull request volledig uit het programma gesloopt. Dit was aardig makkelijk, gezien het feit dat gold alleen werd gebruikt voor de gold cheat en het opslaan van gold.

De gold counter in de HUD is dus verwijderd en de XP counter is op zijn plaats gekomen. De gewonnen ruimte komt tot zijn nut doordat er nu meer ruimte is voor weapon comparisons. De langst mogelijke naam voor een wapen (Divine Avansian Crossbow of Annihilation) past nu precies in het tekstveld.