### PR TITLE
Boss music and health bar issues fixed

### DIFF
--- a/bobberick-demo/systems/AISystem.cpp
+++ b/bobberick-demo/systems/AISystem.cpp
@@ -498,11 +498,11 @@ void AISystem::kill(Entity& entity)
 		auto& enemyTransform = enemy.getComponent<TransformComponent>();
 		enemyTransform.position.x = killedTransform.position.x;
 		enemyTransform.position.y = killedTransform.position.y + 50;
-		initHealthBar(enemy);
 		for (const auto& group : entity.getGroups())
 		{
 			ServiceManager::Instance()->getService<EntityManager>().addEntityToGroup(enemy, group);
 		}
+		initHealthBar(enemy);
 		auto endBossEntities = ServiceManager::Instance()->getService<EntityManager>().getAllEntitiesWithComponent<EndBossComponent>();
 		if (endBossEntities.size() <= 1) {
 			ServiceManager::Instance()->getService<SoundManager>().playMusic("boss", -1);


### PR DESCRIPTION
De issue met de boss muziek is opgelost door te checken of de gespawnde entity wel de eerste met een EndBossComponent is alvorens de boss muziek te beginnen.

De issue met de boss health bar is opgelost door de boss eerst aan de juiste groep toe te voegen en daarna pas initHealthBar() aan te roepen. initHealthBar() moet namelijk op het moment van aanroep weten in welke groep een entity zit om de health bar ook aan die groep toe te kunnen voegen.